### PR TITLE
Swift 3.2 compatibility

### DIFF
--- a/Pod/Classes/FontIcons.swift
+++ b/Pod/Classes/FontIcons.swift
@@ -43,7 +43,7 @@ open class FontLoader {
         let font = CGFont(provider!)
 
         var error: Unmanaged<CFError>?
-        if !CTFontManagerRegisterGraphicsFont(font, &error) {
+        if !CTFontManagerRegisterGraphicsFont(font!, &error) {
 
             let errorDescription: CFString = CFErrorCopyDescription(error!.takeUnretainedValue())
             let nsError = error!.takeUnretainedValue() as AnyObject as! NSError


### PR DESCRIPTION
Just added a forced unwrap for an optional that was impeding the compilation under Xcode 9 with Swift 3.2.

Didn't check the surrounding code, may need some rewrite for exception control.